### PR TITLE
Raincatch 210 - build errors on a mac when installing raincatcher locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cors": "2.7.1",
     "dotenv": "2.0.0",
     "express": "4.13.4",
-    "fh-mbaas-api": "5.13.1",
+    "fh-mbaas-api": "5.14.2",
     "fh-wfm-mediator": "0.0.15",
     "fh-wfm-template-build": "0.0.9",
     "mochify": "2.17.0",


### PR DESCRIPTION
# Issue
Getting node-gyp build errors on a mac when installing raincatcher locally
Caused by dtrace-provider version used in older version of bunyan in `fh-mbaas-client`which was updated in latest `fh-mbaas-api`
# Solution
Update `fh-mbaas-api`


# JIRA
https://issues.jboss.org/browse/RAINCATCH-210