### PR TITLE
Moving the submission complete to the raincatcher-appform module.

### DIFF
--- a/lib/angular/directive.js
+++ b/lib/angular/directive.js
@@ -60,7 +60,9 @@ ngModule.directive('appform', function($templateCache, $q, mediator, appformClie
   , template: $templateCache.get('wfm-template/appform.tpl.html')
   , scope: {
       form: '=',
-      formId: '='
+      formId: '=',
+      workorderId: '=',
+      stepCode:'='
     }
   , controller: function($scope, $element) {
     var self = this;
@@ -73,18 +75,18 @@ ngModule.directive('appform', function($templateCache, $q, mediator, appformClie
       _.forEach(self.fields, function(field) {
         self.model[field.props.fieldCode || field.props._id] = {};
       });
-    })
+    });
     self.back = function(event) {
       event.preventDefault();
       event.stopPropagation();
       mediator.publish('wfm:workflow:step:back');
-    }
+    };
     self.done = function(event, isValid) {
       event.stopPropagation();
       event.stopPropagation();
       $scope.$broadcast('parentFormSubmitted');
       if (!isValid) {
-        console.log('invalid', event)
+        console.log('invalid', event);
         var firstInvalid = $element[0].querySelector('input.ng-invalid');
         // if we find one, set focus
         if (firstInvalid) {
@@ -98,17 +100,21 @@ ngModule.directive('appform', function($templateCache, $q, mediator, appformClie
             fieldId: field.props._id,
             value: value
           });
+        });
+        appformClient.createSubmission(form, submissionFields, {
+          workorderId: $scope.workorderId,
+          stepCode: $scope.stepCode
         })
-        appformClient.createSubmission(form, submissionFields)
         .then(appformClient.submitSubmission)
         .then(appformClient.composeSubmissionResult)
         .then(function(submissionResult) {
           mediator.publish('wfm:workflow:step:done', submissionResult);
+          return submissionResult;
         }, function(error) {
           console.error('submissionFields', submissionFields);
           throw new Error(error);
-        });
-      };
+        }).then(appformClient.syncStepResult);
+      }
     }
   }
   , controllerAs: 'ctrl'

--- a/lib/appform-mediator.js
+++ b/lib/appform-mediator.js
@@ -98,16 +98,17 @@ function wrapper(mediator) {
     });
   });
 
+  //A submission upload has completed, we can now update the relevant result.
   client.addSubmissionCompleteListener(function(submissionResult, metaData) {
-    if (metaData) {
-      var event = {
-        submissionResult: submissionResult,
-        metaData: metaData
-      }
-      console.log('metaData', metaData);
-      mediator.publish('wfm:appform:submission:complete', event)
+    //If there is no wfm metadata, then this submission is not related to a wfm workflow.
+    if (metaData && metaData.wfm) {
+      mediator.publish('wfm:workflows:step:complete', {
+        submission: submissionResult,
+        workorderId: metaData.wfm.workorderId,
+        stepCode: metaData.wfm.stepCode
+      });
     }
-  })
-};
+  });
+}
 
 module.exports = wrapper;

--- a/lib/appform.js
+++ b/lib/appform.js
@@ -28,7 +28,7 @@ client.init = function() {
       }
     });
   });
-  $fh.forms.on("submission:submitted", function(submissionId) {
+  $fh.forms.on("submission:submitted", function() {
     var submission = this;
     var metaData = submission.get('metaData');
     if (self.listeners.length) {
@@ -152,12 +152,27 @@ client.getFields = function(submission) {
 }
 
 /**
-* The fields parameter is an array of {fieldId: <...>, value: <...>} objects
+*  Creating a new submission for a single form with a set of fields.
+ *
+ *  Any metadata related to the workorder and step is also added here.
+ *
+ * @param {Form} form - The full form model
+ * @param {Array} submissionFields - An array of {fieldId: <...>, value: <...>} objects
+ * @param {Object} metaData - Metadata to include in the submission
+ * @param {string} metaData.workorderId - The ID of the workorder that this submission relates to.
+ * @param {string} metaData.stepCode    - The code of the step that this field relates to.
 */
-client.createSubmission = function(form, submissionFields) {
+client.createSubmission = function(form, submissionFields, metaData) {
   var deferred = q.defer();
   initPromise.then(function() {
     var submission = form.newSubmission();
+    submission.set('metaData', {
+      wfm: {
+        workorderId: metaData.workorderId,
+        stepCode: metaData.stepCode
+      }
+    });
+
     var ds = [];
     _.forEach(submissionFields, function(field) {
       var d = q.defer();
@@ -196,19 +211,14 @@ client.submitSubmission = function(submission) {
 
 client.uploadSubmission = function(submission) {
   var deferred = q.defer();
+
   initPromise.then(function() {
-    submission.upload(function(error, uploadTask) {
+    submission.upload(function(error) {
       if (error) {
         deferred.reject(new Error(error));
-        return;
-      };
-      uploadTask.submissionModel(function(error, submissionModel) {
-        if (error) {
-          deferred.reject(new Error(error));
-          return;
-        };
-        deferred.resolve(submissionModel);
-      })
+      }
+
+      deferred.resolve(submission);
     });
   });
   return deferred.promise;
@@ -226,29 +236,19 @@ client.composeSubmissionResult = function(submission) {
   return q.when(submissionResult);
 };
 
-client.syncStepResult = function(workorder, stepResult) {
+client.syncStepResult = function(submissionResult) {
   // kick-off an appform upload, update the workorder when complete
   var self = this;
 
   return initPromise
     .then(function() {
-      return self.getSubmissionLocal(stepResult.submission.submissionLocalId);
+      return self.getSubmissionLocal(submissionResult.submissionLocalId);
     })
-    .then(function(submission) {
-      submission.set('metaData', {
-        wfm: {
-          workorderId: workorder.id,
-          step: stepResult.step,
-          timestamp: stepResult.timestamp
-        }
-      });
-      return submission;
-    })
-    .then(self.uploadSubmission)
     .then(function(submissionModel) {
       self.watchSubmissionModel(submissionModel); // need this to trigget the global event
       return submissionModel;
-    });
+    })
+    .then(self.uploadSubmission);
 };
 
 client.watchSubmissionModel = function(submissionModel) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-appform",
-  "version": "0.0.25",
+  "version": "0.1.0",
   "description": "An appform module for WFM",
   "main": "lib/angular/appform-ng.js",
   "repository": {


### PR DESCRIPTION
# Motivation

Originally, the raincatcher-appform module would publish the `wfm:workflow:step:done` topic and then then the raincatcher-result module would subscribe to the `wfm:appform:submission:complete` topic (https://github.com/feedhenry-raincatcher/raincatcher-result/pull/19/files#diff-258aba1827ed41a4771f753a1be5d070L81). 

However, it shouldn't be the responsibility of the raincatcher-result module to monitor the appform module topics. Like any other step, it is the responsibility of the individual step to notify the raincatcher-workflow module when the step has completed. In the case of appforms, the step has completed when the submission has been successfully uploaded.

# Changes

 - Added `workorderId` and `stepCode` parameters to the appform directive. (Related to https://github.com/feedhenry-raincatcher/raincatcher-workflow-angular/pull/3)
- Monitoring the submission for the `submitted` event emitted by the $fh.forms Client API. When this event is emitted, the `wfm:workflow:step:complete` topic is published with the relevant workorderId and stepCode.